### PR TITLE
Do not error out when no credentials are provided

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,10 @@ async function run(): Promise<void> {
   try {
     const netlifyAuthToken = process.env.NETLIFY_AUTH_TOKEN
     const siteId = process.env.NETLIFY_SITE_ID
+    if (!(netlifyAuthToken && siteId)) {
+      process.stdout.write('Netlify credentials not provided, not deployable')
+      return
+    }
     const dir = core.getInput('publish-dir', {required: true})
     const productionBranch = core.getInput('production-branch')
     // NOTE: if production-branch is not specified, it is "", so isDraft is always true


### PR DESCRIPTION
Right now, if Netlify credentials are not provided, this action terminates with an error.

But GitHub currently doesn't provide secrets (with Netlify credentials) to GitHub actions triggered by PRs from forks. They are only provided to actions triggered by PRs from branches on the same repo.

This means that if someone sends a PR with changes from a fork, it's currently not possible to deploy a preview (it's currently just not supported by GitHub), and this action will always report an error in those cases.

The change in this PR makes the action just _not_ run in that case, not deploying, instead of exiting with an error. And that way it lets the rest of the CI run.