### PR TITLE
Add extra input option to determine production deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,7 @@ Thumbs.db
 # Ignore built ts files
 __tests__/runner/*
 lib/**/*
+
+# Intellij
+
+.idea/

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -130,7 +130,7 @@ describe('defaultInputs', () => {
       })
     })
 
-    test('it should be true when "false" specified', () => {
+    test('it should be false when "false" specified', () => {
       withInput('overwrites-pull-request-comment', 'false', () => {
         const b: boolean = defaultInputs.overwritesPullRequestComment()
         expect(b).toBe(false)
@@ -143,6 +143,27 @@ describe('defaultInputs', () => {
       withInput('alias', 'foo', () => {
         const alias: string | undefined = defaultInputs.alias()
         expect(alias).toBe('foo')
+      })
+    })
+  })
+
+  describe('production deploy', () => {
+    test('it should be default value (false) when not specified', () => {
+      const b: boolean = defaultInputs.productionDeploy()
+      expect(b).toBe(false)
+    })
+
+    test('it should be true when "true" specified', () => {
+      withInput('production-deploy', 'true', () => {
+        const b: boolean = defaultInputs.productionDeploy()
+        expect(b).toBe(true)
+      })
+    })
+
+    test('it should be false when "false" specified', () => {
+      withInput('production-deploy', 'false', () => {
+        const b: boolean = defaultInputs.productionDeploy()
+        expect(b).toBe(false)
       })
     })
   })

--- a/__tests__/production-deploy.test.ts
+++ b/__tests__/production-deploy.test.ts
@@ -1,0 +1,85 @@
+import * as path from 'path'
+import {defaultInputs} from '../src/inputs'
+import {context} from '@actions/github'
+import {run} from '../src/main'
+import Mock = jest.Mock
+
+const mockDeploy = jest.fn()
+
+jest.mock('netlify', () => {
+  return jest.fn().mockImplementation(() => {
+    return {deploy: mockDeploy}
+  })
+})
+jest.mock('../src/inputs')
+jest.mock('@actions/github')
+
+mockDeploy.mockResolvedValue({deploy: {}})
+;(<Mock<any>>defaultInputs.githubToken).mockReturnValue('')
+;(<Mock<any>>defaultInputs.publishDir).mockReturnValue('publish-dir')
+
+process.env.NETLIFY_AUTH_TOKEN = 'auth-token'
+process.env.NETLIFY_SITE_ID = 'site-id'
+
+describe('Draft deploy', () => {
+  const expectedDeployFolder = path.resolve(process.cwd(), 'publish-dir')
+
+  test('deploy should have draft true when production-deploy input is false', async () => {
+    ;(<Mock<any>>defaultInputs.productionDeploy).mockReturnValue(false)
+
+    await run(defaultInputs)
+
+    expect(mockDeploy).toHaveBeenCalledWith('site-id', expectedDeployFolder, {
+      draft: true
+    })
+  })
+
+  test('deploy should have draft false when production-deploy input is true', async () => {
+    ;(<Mock<any>>defaultInputs.productionDeploy).mockReturnValue(true)
+
+    await run(defaultInputs)
+
+    expect(mockDeploy).toHaveBeenCalledWith('site-id', expectedDeployFolder, {
+      draft: false
+    })
+  })
+
+  test('deploy should have draft false when production-branch matches context ref', async () => {
+    ;(<Mock<any>>defaultInputs.productionDeploy).mockReturnValue(false)
+    ;(<Mock<any>>defaultInputs.productionBranch).mockReturnValue('master')
+
+    context.ref = 'refs/heads/master'
+
+    await run(defaultInputs)
+
+    expect(mockDeploy).toHaveBeenCalledWith('site-id', expectedDeployFolder, {
+      draft: false
+    })
+  })
+
+  test('deploy should have draft true when production-branch doesnt match context ref', async () => {
+    ;(<Mock<any>>defaultInputs.productionDeploy).mockReturnValue(false)
+    ;(<Mock<any>>defaultInputs.productionBranch).mockReturnValue('master')
+
+    context.ref = 'refs/heads/not-master'
+
+    await run(defaultInputs)
+
+    expect(mockDeploy).toHaveBeenCalledWith('site-id', expectedDeployFolder, {
+      draft: true
+    })
+  })
+
+  test('deploy should have draft true when production-branch is not defined', async () => {
+    ;(<Mock<any>>defaultInputs.productionDeploy).mockReturnValue(false)
+    ;(<Mock<any>>defaultInputs.productionBranch).mockReturnValue(undefined)
+
+    context.ref = 'refs/heads/master'
+
+    await run(defaultInputs)
+
+    expect(mockDeploy).toHaveBeenCalledWith('site-id', expectedDeployFolder, {
+      draft: true
+    })
+  })
+})

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,9 @@ inputs:
   production-branch:
       description: Production branch
       required: false
+  production-deploy:
+      description: Indicate wether to deploy production build
+      required: false
   enable-pull-request-comment:
       description: Enable pull request comment
       required: false

--- a/src/inputs.ts
+++ b/src/inputs.ts
@@ -5,6 +5,7 @@ export interface Inputs {
   publishDir(): string
   deployMessage(): string | undefined
   productionBranch(): string | undefined
+  productionDeploy(): boolean
   enablePullRequestComment(): boolean
   enableCommitComment(): boolean
   githubToken(): string
@@ -22,6 +23,10 @@ export const defaultInputs: Inputs = {
   },
   productionBranch() {
     return core.getInput('production-branch') || undefined
+  },
+  productionDeploy(): boolean {
+    // Default: false
+    return core.getInput('production-deploy') === 'true'
   },
   enablePullRequestComment() {
     // Default: true

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "rootDir": "./src",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
     "strict": true,                           /* Enable all strict type-checking options. */
     "noImplicitAny": true,                    /* Raise error on expressions and declarations with an implied 'any' type. */
-    "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    "esModuleInterop": true                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
   },
   "exclude": ["node_modules", "**/*.test.ts", "dist"]
 }


### PR DESCRIPTION
I was running into a problem while trying to deploy my site to 'production' when the action was triggered by pushing a new tag. I noticed Issue #102 already existed which deals with the same problem, so I took a stab at implementing it. If I followed the discussion correctly the consensus was to name the input property `production-deploy`, if not that's an easy rename.

I also added a unit test (only for this draft boolean though, not every option) but I'm not a natural at Jest so that might require some tweaking. 

I'm already using this branch in my private repo so it does work :-)