### PR TITLE
feat: support netlify functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ jobs:
 - `enable-commit-comment: true` Comment on GitHub commit (default: true)
 - `overwrites-pull-request-comment: true` Overwrites comment on pull request (default: true)
 - `netlify-config-path: ./netlify.toml` Path to `netlify.toml` (default: undefined)
+- `functions-dir` Netlify functions output directory (default: undefined)
 - `alias` Specifies the prefix for the deployment URL (default: Netlify build ID)
   - `alias: ${{ github.head_ref }}` replicates the [branch deploy prefix](https://docs.netlify.com/site-deploys/overview/#definitions)
   - `alias: deploy-preview-${{ github.event.number }}` replicates the [deploy preview prefix](https://docs.netlify.com/site-deploys/overview/#definitions)

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -31,6 +31,20 @@ describe('defaultInputs', () => {
     })
   })
 
+  describe('functionsDir', () => {
+    test('it should be a string when specified', () => {
+      withInput('functions-dir', './my_functions_dir', () => {
+        const functionsDir: string | undefined = defaultInputs.functionsDir()
+        expect(functionsDir).toBe('./my_functions_dir')
+      })
+    })
+
+    test('it should be undefined when not specified', () => {
+      const functionsDir: string | undefined = defaultInputs.functionsDir()
+      expect(functionsDir).toBe(undefined)
+    })
+  })
+
   describe('deployMessage', () => {
     test('it should be a string when specified', () => {
       withInput('deploy-message', 'Deploy with GitHub Actions', () => {

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,9 @@ inputs:
   publish-dir:
     description: Publish directory
     required: true
+  functions-dir:
+    description: Functions directory
+    required: false
   deploy-message:
     description: Custom deploy message for Netlify
     required: false

--- a/src/inputs.ts
+++ b/src/inputs.ts
@@ -3,6 +3,7 @@ import * as core from '@actions/core'
 // Why use function rather than raw string? => Inputs should be lazy evaluated.
 export interface Inputs {
   publishDir(): string
+  functionsDir(): string | undefined
   deployMessage(): string | undefined
   productionBranch(): string | undefined
   productionDeploy(): boolean
@@ -17,6 +18,9 @@ export interface Inputs {
 export const defaultInputs: Inputs = {
   publishDir() {
     return core.getInput('publish-dir', {required: true})
+  },
+  functionsDir() {
+    return core.getInput('functions-dir') || undefined
   },
   deployMessage() {
     return core.getInput('deploy-message') || undefined

--- a/src/main.ts
+++ b/src/main.ts
@@ -64,6 +64,7 @@ export async function run(inputs: Inputs): Promise<void> {
       return
     }
     const dir = inputs.publishDir()
+    const functionsDir: string | undefined = inputs.functionsDir()
     const deployMessage: string | undefined = inputs.deployMessage()
     const productionBranch: string | undefined = inputs.productionBranch()
     const enablePullRequestComment: boolean = inputs.enablePullRequestComment()
@@ -80,12 +81,16 @@ export async function run(inputs: Inputs): Promise<void> {
     const netlifyClient = new NetlifyAPI(netlifyAuthToken)
     // Resolve publish directory
     const deployFolder = path.resolve(process.cwd(), dir)
+    // Resolve functions directory
+    const functionsFolder =
+      functionsDir && path.resolve(process.cwd(), functionsDir)
     // Deploy to Netlify
     const deploy = await netlifyClient.deploy(siteId, deployFolder, {
       draft: !productionDeploy,
       message: deployMessage,
       configPath: netlifyConfigPath,
-      branch: alias
+      branch: alias,
+      fnDir: functionsFolder
     })
     // Create a message
     const message = productionDeploy


### PR DESCRIPTION
Sets `fnDir` in netlify client if the `functions-dir` input is specified.

See: https://github.com/netlify/js-client#deploy--await-clientdeploysiteid-builddir-opts

Updated docs and tests