### PR TITLE
fix: ignore alias deployment when production deployment

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -94,9 +94,15 @@ export async function run(inputs: Inputs): Promise<void> {
       draft: !productionDeploy,
       message: deployMessage,
       configPath: netlifyConfigPath,
-      branch: alias,
+      ...(productionDeploy ? {} : {branch: alias}),
       fnDir: functionsFolder
     })
+    if (productionDeploy && alias !== undefined) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `Only production deployment was conducted. The alias ${alias} was ignored.`
+      )
+    }
     // Create a message
     const message = productionDeploy
       ? `🎉 Published on ${deploy.deploy.ssl_url} as production\n🚀 Deployed on ${deploy.deploy.deploy_ssl_url}`


### PR DESCRIPTION
To solve #204.
Closes #204.

I decided to ignore alias deployment when production deployment. Deployment should be failed as much as possible, especially production deployment. When both production and alias deployments are specified, this action warns.