### PR TITLE
Write to stderr on no credentials

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -65,7 +65,7 @@ export async function run(inputs: Inputs): Promise<void> {
     const siteId = process.env.NETLIFY_SITE_ID
     // NOTE: Non-collaborators PRs don't pass GitHub secrets to GitHub Actions.
     if (!(netlifyAuthToken && siteId)) {
-      process.stdout.write('Netlify credentials not provided, not deployable')
+      process.stderr.write('Netlify credentials not provided, not deployable')
       return
     }
     const dir = inputs.publishDir()


### PR DESCRIPTION
I don't write TypeScript usually but I think this could work.
For Github Actions it's probably nicer if we get a non-0 return value so the Action actually fails.