### PR TITLE
Make deployment link on pull request if CI is running on pull request

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -45,13 +45,13 @@ async function createGitHubDeployment(
   environment: string,
   description: string | undefined
 ): Promise<void> {
-  const {ref} = context
+  const deployRef = context.payload.pull_request?.head.sha ?? context.sha
   const deployment = await githubClient.repos.createDeployment({
     // eslint-disable-next-line @typescript-eslint/camelcase
     auto_merge: false,
     owner: context.repo.owner,
     repo: context.repo.repo,
-    ref,
+    ref: deployRef,
     environment,
     description,
     // eslint-disable-next-line @typescript-eslint/camelcase


### PR DESCRIPTION
This action has a bug where the deployment link doesn't show on pull request.

Expected: A deployment link is shown in PR timeline:
 
![image](https://user-images.githubusercontent.com/1018196/116178032-bb8ab880-a6c9-11eb-9121-22bec3ce12e4.png)
