### PR TITLE
Added string replace to alias

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -92,7 +92,7 @@ export async function run(inputs: Inputs): Promise<void> {
     const overwritesPullRequestComment: boolean =
       inputs.overwritesPullRequestComment()
     const netlifyConfigPath: string | undefined = inputs.netlifyConfigPath()
-    const alias: string | undefined = inputs.alias()
+    const alias: string | undefined = (inputs.alias() || "").replace("/", "-");
 
     const branchMatchesProduction: boolean =
       !!productionBranch && context.ref === `refs/heads/${productionBranch}`


### PR DESCRIPTION
This is a workaround to netlify/cli/issues/969, which causes the deploy to fail if the alias contains a slash. It shows as deployed and returns a URL but when visiting the URL the only thing that shows is `Not Found - Request ID: 01FH0A64F9VFQNQBRDQEZ8V3MY` . 