### PR TITLE
add: auto_inactive:false to createDeploymentStatus

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -55,12 +55,9 @@ async function createGitHubDeployment(
     environment,
     description,
     // eslint-disable-next-line @typescript-eslint/camelcase
-    required_contexts: []
+    required_contexts: [],
   })
   await githubClient.repos.createDeploymentStatus({
-    headers: {
-      accept: 'application/vnd.github.v3+json',
-    },
     state: 'success',
     // eslint-disable-next-line @typescript-eslint/camelcase
     auto_inactive: false,
@@ -71,7 +68,11 @@ async function createGitHubDeployment(
     // eslint-disable-next-line @typescript-eslint/camelcase
     deployment_id: (
       deployment as OctokitResponse<ReposCreateDeploymentResponseData>
-    ).data.id
+    ).data.id,
+    mediaType: {
+      // required for auto_inactive flag
+      previews: ['ant-man', 'flash'],
+    }
   })
 }
 
@@ -145,7 +146,7 @@ export async function run(inputs: Inputs): Promise<void> {
     const markdownComment = `${getCommentIdentifier(siteId)}\n${message}`
 
     // Create GitHub client
-    const githubClient = getOctokit(githubToken)
+    const githubClient = getOctokit(githubToken, {log: console})
 
     if (enableCommitComment) {
       const commitCommentParams = {

--- a/src/main.ts
+++ b/src/main.ts
@@ -58,6 +58,9 @@ async function createGitHubDeployment(
     required_contexts: []
   })
   await githubClient.repos.createDeploymentStatus({
+    headers: {
+      accept: 'application/vnd.github.v3+json',
+    },
     state: 'success',
     // eslint-disable-next-line @typescript-eslint/camelcase
     auto_inactive: false,

--- a/src/main.ts
+++ b/src/main.ts
@@ -60,6 +60,8 @@ async function createGitHubDeployment(
   await githubClient.repos.createDeploymentStatus({
     state: 'success',
     // eslint-disable-next-line @typescript-eslint/camelcase
+    auto_inactive: false,
+    // eslint-disable-next-line @typescript-eslint/camelcase
     environment_url: environmentUrl,
     owner: context.repo.owner,
     repo: context.repo.repo,


### PR DESCRIPTION
Github automatically makes any previous environments stale, if there is a new deployment status. With Netlify, the urls still remain valid even if there is a new status. 

In our case, we use netlify for PR builds i.e every commit gets a unique netlify link. The issue is Github UI loses that link when anyone else adds a new commit. 

By making auto_inactive: false, the links would preserve and Github's UI would be useful.

![image](https://user-images.githubusercontent.com/1018196/153103324-0d3a4990-f5fa-4614-b86b-170e18abd9df.png)
