### PR TITLE
chore: upgrade to node v16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -51,5 +51,5 @@ outputs:
   deploy-url:
     description: Deploy URL
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
Hey 👋🏻

This action recently started to emit a warning about Node.js 12 actions being deprecated - [GitHub Actions: All Actions will begin running on Node16 instead of Node12](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/)

This pull request's intention is to address the upgrade to node v16.

Great job with this action!