### PR TITLE
feat: allow keeping previous deployments active

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ jobs:
   - `alias: ${{ github.head_ref }}` replicates the [branch deploy prefix](https://docs.netlify.com/site-deploys/overview/#definitions)
   - `alias: deploy-preview-${{ github.event.number }}` replicates the [deploy preview prefix](https://docs.netlify.com/site-deploys/overview/#definitions)
 - `enable-github-deployment` Whether or not to deploy to GitHub (default: true)
+- `github-deployment-auto-inactive` Whether to mark previous deployments to the environment as inactive (Default: true)
 - `github-deployment-environment` Environment name of GitHub Deployments
 - `github-deployment-description` Description of the GitHub Deployment
 - `fails-without-credentials` Fails if no credentials provided (default: false)

--- a/action.yml
+++ b/action.yml
@@ -41,6 +41,9 @@ inputs:
   enable-github-deployment:
     description: Whether or not to deploy to GitHub
     required: false
+  github-deployment-auto-inactive:
+      description: Whether to mark previous deployments to the environment as inactive
+      required: false
   github-deployment-environment:
     description: Environment name of GitHub Deployments
     required: false

--- a/src/inputs.ts
+++ b/src/inputs.ts
@@ -15,6 +15,7 @@ export interface Inputs {
   netlifyConfigPath(): string | undefined
   alias(): string | undefined
   enableGithubDeployment(): boolean
+  githubDeploymentAutoInactive(): boolean
   githubDeploymentEnvironment(): string | undefined
   githubDeploymentDescription(): string | undefined
   failsWithoutCredentials(): boolean
@@ -67,6 +68,10 @@ export const defaultInputs: Inputs = {
   enableGithubDeployment() {
     // Default: true
     return (core.getInput('enable-github-deployment') || 'true') === 'true'
+  },
+  githubDeploymentAutoInactive() {
+    // Default: true
+    return (core.getInput('github-deployment-auto-inactive') || 'true') === 'true'
   },
   githubDeploymentEnvironment(): string | undefined {
     return core.getInput('github-deployment-environment') || undefined

--- a/src/main.ts
+++ b/src/main.ts
@@ -41,7 +41,8 @@ async function createGitHubDeployment(
   githubClient: InstanceType<typeof GitHub>,
   environmentUrl: string,
   environment: string,
-  description: string | undefined
+  description: string | undefined,
+  autoInactive: boolean,
 ): Promise<void> {
   const deployRef = context.payload.pull_request?.head.sha ?? context.sha
   const deployment = await githubClient.rest.repos.createDeployment({
@@ -58,7 +59,8 @@ async function createGitHubDeployment(
     environment_url: environmentUrl,
     owner: context.repo.owner,
     repo: context.repo.repo,
-    deployment_id: (deployment.data as {id: number}).id
+    deployment_id: (deployment.data as { id: number }).id,
+    auto_inactive: autoInactive
   })
 }
 
@@ -192,13 +194,16 @@ export async function run(inputs: Inputs): Promise<void> {
             ? 'pull request'
             : 'commit')
 
+        const autoInactive = inputs.githubDeploymentAutoInactive()
+
         const description = inputs.githubDeploymentDescription()
         // Create GitHub Deployment
         await createGitHubDeployment(
           githubClient,
           deployUrl,
           environment,
-          description
+          description,
+          autoInactive
         )
       } catch (err) {
         // eslint-disable-next-line no-console


### PR DESCRIPTION
New deployments override the currently active one, making previous revisions inaccessible.
Github supports setting `auto_inactive = false` to avoid that.
I think this is useful, since Netlify creates permalinks for all deployments fo a reason. 