### PR TITLE
Bump action runtime to Node 24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -54,5 +54,5 @@ outputs:
   deploy-url:
     description: Deploy URL
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'


### PR DESCRIPTION
## Summary

GitHub is [deprecating Node 20 for JavaScript actions](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/). Runners will force Node 24 by default starting **2026-06-02**, and Node 20 will be removed entirely on **2026-09-16**. Until then, this action emits a deprecation warning on every run:

> Node.js 20 actions are deprecated. ... `nwtgck/actions-netlify@v3.0` ...

This PR bumps the action runtime in `action.yml` from `node20` to `node24` to silence the warning and keep the action working past the removal date.

The bundled `dist/index.js` is precompiled JavaScript executed by the runner-provided Node, so no rebuild is required for the runtime change.

Refs #1222

## Note / out of scope

The repo's own CI (`.github/workflows/test.yml`) still uses `actions/setup-node@v4`, `actions/checkout@v4`, and `ubuntu-20.04`, which carry their own deprecations. I left those alone to keep this PR focused on the action runtime; happy to follow up separately if you'd like.

## Test plan

- [ ] CI build/test passes on the fork's branch
- [ ] Action loads and runs under the Node 24 runtime